### PR TITLE
(VNST-1243) Update build-in-docker.sh for improved compatibility and functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,28 @@ If you want to use this template or enhance it, you can choose between using Doc
 
 Just run `./build-in-docker.sh` and then point your browser to [http://localhost:4000/](http://localhost:4000/).
 
+#### First-time setup
+
+Make sure the Docker helper script is executable:
+
+```sh
+chmod +x build-in-docker.sh
+```
+
+If the repository was cloned or edited on **Windows**, also ensure the file uses Unix line endings:
+
+```sh
+sed -i 's/\r$//' build-in-docker.sh
+```
+
+Why this is needed:
+
+- `chmod +x` ensures the script can be executed on Linux/WSL and inside Docker.
+
+- Windows CRLF line endings can make shell scripts fail when run in Linux containers, resulting in errors like `/bin/sh^M: bad interpreter`.
+
+*These commands only need to be run once.*
+
 ### Option 2: Running Locally
 
 #### Requirements

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -4,6 +4,8 @@ set -e
 if command -v pwd >/dev/null 2>&1 && pwd -W >/dev/null 2>&1; then
   # Git Bash / Windows
   HOST_PWD="$(pwd -W)"
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL="*"
 else
   # Linux / WSL / macOS
   HOST_PWD="$(pwd)"

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-if command -v pwd >/dev/null 2>&1 && pwd -W >/dev/null 2>&1; then
+if pwd -W >/dev/null 2>&1; then
   # Git Bash / Windows
   HOST_PWD="$(pwd -W)"
   export MSYS_NO_PATHCONV=1

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -14,13 +14,14 @@ fi
 if [ -z "$1" ]; then
   docker pull jekyll/builder:pages
   docker run -it --rm \
+    --entrypoint "" \
     --workdir /srv/jekyll \
     --volume "$HOST_PWD:/srv/jekyll" \
     --volume "$HOST_PWD/vendor/bundle:/usr/local/bundle" \
     --publish 4000:4000 \
     --publish 4001:4001 \
     jekyll/builder:pages \
-    ./build-in-docker.sh build
+    sh ./build-in-docker.sh build
 else
   bundle install --jobs=4
   bundle exec jekyll serve \

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -23,7 +23,11 @@ if [ -z "$1" ]; then
     jekyll/builder:pages \
     sh ./build-in-docker.sh build
 else
-  bundle install --jobs=4
+  bundle install \
+    --jobs=4 \
+    --retry=3 \
+    --verbose
+
   bundle exec jekyll serve \
     -H 0.0.0.0 \
     --trace \

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -14,7 +14,8 @@ fi
 mkdir -p vendor/bundle
 
 if [ -z "$1" ]; then
-  docker pull jekyll/builder:pages
+  docker pull jekyll/builder:4
+
   docker run -it --rm \
     --entrypoint "" \
     --workdir /srv/jekyll \
@@ -22,9 +23,11 @@ if [ -z "$1" ]; then
     --volume "$HOST_PWD/vendor/bundle:/usr/local/bundle" \
     --publish 4000:4000 \
     --publish 4001:4001 \
-    jekyll/builder:pages \
+    jekyll/builder:4 \
     sh ./build-in-docker.sh build
 else
+  set -x
+
   bundle install \
     --jobs=4 \
     --retry=3 \

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -1,11 +1,20 @@
 #!/bin/sh
+set -e
+
+if command -v pwd >/dev/null 2>&1 && pwd -W >/dev/null 2>&1; then
+  # Git Bash / Windows
+  HOST_PWD="$(pwd -W)"
+else
+  # Linux / WSL / macOS
+  HOST_PWD="$(pwd)"
+fi
 
 if [ -z "$1" ]; then
   docker pull jekyll/builder:pages
   docker run -it --rm \
     --workdir /srv/jekyll \
-    --volume="$PWD:/srv/jekyll:Z" \
-    --volume="$PWD/vendor/bundle:/usr/local/bundle:Z" \
+    --volume "$HOST_PWD:/srv/jekyll" \
+    --volume "$HOST_PWD/vendor/bundle:/usr/local/bundle" \
     --publish 4000:4000 \
     --publish 4001:4001 \
     jekyll/builder:pages \

--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -11,6 +11,8 @@ else
   HOST_PWD="$(pwd)"
 fi
 
+mkdir -p vendor/bundle
+
 if [ -z "$1" ]; then
   docker pull jekyll/builder:pages
   docker run -it --rm \


### PR DESCRIPTION
This pull request updates the `build-in-docker.sh` script to improve compatibility across operating systems and enhance reliability when running Jekyll builds in Docker. The main changes focus on better handling of path conversion for Windows environments, updating the Docker image, and making the build process more robust and verbose.

**Cross-platform compatibility improvements:**

* Added logic to detect if the script is running on Windows (Git Bash) versus Linux/WSL/macOS, and set `HOST_PWD` accordingly to ensure correct path handling inside Docker. Also sets `MSYS_NO_PATHCONV` and `MSYS2_ARG_CONV_EXCL` to prevent unwanted path conversion on Windows.
* Changed Docker volume mounts to use `HOST_PWD` for cross-platform compatibility, replacing the previous use of `$PWD` and removing the `:Z` SELinux flag for broader compatibility.

**Build process enhancements:**

* Updated the Docker image from `jekyll/builder:pages` to `jekyll/builder:4` for a more current Jekyll environment. @LucasVianaa please ensure this change won't cause breaks in the server, since this builder has more features.
* Added `set -e` to exit the script on any error, and `set -x` for verbose output during the build process, making debugging easier.
* Improved the `bundle install` command with retry and verbose options for