### PR TITLE
Update video URL

### DIFF
--- a/index.md
+++ b/index.md
@@ -24,7 +24,7 @@ sections:
   - type: embed-video.html
     section_id: video
     title: Assista ao Vídeo
-    video_url: https://drive.google.com/file/d/1_dR6PgWoP1krUWtSleHvuryxPSe262YW/preview
+    video_url: https://imt-static-files.s3.us-east-1.amazonaws.com/insaight-trailer.mp4
 
   - type: services.html
     section_id: solucoes


### PR DESCRIPTION
This pull request updates the video embed in the `index.md` file to use a new video hosting location. The video URL has been changed from a Google Drive link to an S3 bucket link for improved reliability and performance.

- Switched the `video_url` in the `embed-video.html` section from a Google Drive link to an S3-hosted `.mp4` file (`index.md`).